### PR TITLE
Pin to poppler v24.09.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,15 @@ source:
   sha256: e6ca5c23ec02350bf2cef85a6bf9f1b261796436db478176f9d24fb14eeecc6a
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv # [unix]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
   
 requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - pkg-config
-    
   host:
     - python
     - pip
@@ -28,15 +27,14 @@ requirements:
     - pybind11
     - meson >=1.1.0
     - meson-python 
-    - poppler 22.12.0
+    - poppler 24.09.0
   run:
     - python
-    - poppler
+    - {{ pin_compatible('poppler', max_pin='x.x.x') }}
 
 test:
   imports:
     - poppler
-
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 1
-  skip: True  # [py<37]
+  # Poppler >=24.09.0 requires Qt which does not exist on s390x.
+  skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
   
 requirements:


### PR DESCRIPTION
python-poppler 0.4.1

**Destination channel:** defaults

### Links

- [PKG-6111](https://anaconda.atlassian.net/browse/PKG-6111)
- [Upstream repository](https://github.com/cbrunet/python-poppler/tree/v0.4.1)

### Explanation of changes:

- Update poppler pinnings


[PKG-6111]: https://anaconda.atlassian.net/browse/PKG-6111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ